### PR TITLE
Add persistent option to Mysql Driver.

### DIFF
--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -98,6 +98,10 @@ class Mysql extends Base
             $options[PDO::MYSQL_ATTR_SSL_CA] = $settings['ssl_ca'];
         }
 
+        if (! empty($settings['persistent'])) {
+            $options[PDO::ATTR_PERSISTENT] = $settings['persistent'];
+        }
+
         return $options;
     }
 


### PR DESCRIPTION
When using raw PDO I commonly use the persistent option during unit testing so the tests run faster and I don't run out of database connections. I thought it'd be helpful to have this option in PicoDB as well since I've been using it a lot now.

Tell me what you think, thanks!